### PR TITLE
Improvements to the theme_url setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ htmlcov/
 mkdocs.egg-info/
 *.pyc
 .coverage
+.mkdocs

--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -3,7 +3,6 @@
 from mkdocs import utils
 from mkdocs.compat import urlparse, URLError
 from mkdocs.exceptions import ConfigurationError
-import mkdocs
 
 import logging
 from io import BytesIO
@@ -159,8 +158,7 @@ def validate_config(user_config):
 
     if config['theme_url']:
         config_dir = os.path.dirname(config['config'])
-        dl_theme_dir = os.path.join(
-            config_dir, '.mkdocs/%s/theme' % mkdocs.__version__)
+        dl_theme_dir = os.path.join(config_dir, '.mkdocs/theme')
         install_theme(config['theme_url'], dl_theme_dir)
         theme_dir.insert(0, dl_theme_dir)
 

--- a/mkdocs/config.py
+++ b/mkdocs/config.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 
 from mkdocs import utils
-from mkdocs.compat import urlparse, urlopen, URLError
+from mkdocs.compat import urlparse, URLError
 from mkdocs.exceptions import ConfigurationError
+import mkdocs
 
 import logging
 from io import BytesIO
@@ -95,9 +96,7 @@ def load_config(filename='mkdocs.yml', options=None):
 
 def validate_config(user_config):
     config = DEFAULT_CONFIG.copy()
-
     theme_in_config = 'theme' in user_config
-
     config.update(user_config)
 
     if not config['site_name']:
@@ -148,11 +147,22 @@ def validate_config(user_config):
 
     package_dir = os.path.dirname(__file__)
 
-    if config['theme_url']:
-        install_theme(config['theme_url'],
-                      os.path.join(package_dir, 'themes'))
+    theme_dir = []
 
-    theme_dir = [os.path.join(package_dir, 'themes', config['theme'])]
+    if config['theme'] is not None:
+        internal_theme = os.path.join(package_dir, 'themes', config['theme'])
+        if os.path.exists(internal_theme):
+            theme_dir = [internal_theme, ]
+        else:
+            log.warning(("No theme can be found with the name %s "
+                         "in the builtin MkDocs themes"), config['theme'])
+
+    if config['theme_url']:
+        config_dir = os.path.dirname(config['config'])
+        dl_theme_dir = os.path.join(
+            config_dir, '.mkdocs/%s/theme' % mkdocs.__version__)
+        install_theme(config['theme_url'], dl_theme_dir)
+        theme_dir.insert(0, dl_theme_dir)
 
     if config['theme_dir'] is not None:
         # If the user has given us a custom theme but not a
@@ -195,9 +205,12 @@ def validate_config(user_config):
 
 def install_theme(url, package_dir):
     """Installs a theme from a hosted zip file"""
+
+    log.debug("Downloading theme from: %s", url)
     try:
-        response = urlopen(url)
+        response = utils.urlopen(url)
     except URLError:
+        log.error("Error downloading theme from: %s", url)
         return
     zipfile = response.read()
     # We can't use ZipFile as a ContextManager due to PY26 compatibility

--- a/mkdocs/tests/config_tests.py
+++ b/mkdocs/tests/config_tests.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import filecmp
 import os
 import shutil
 import tempfile
 import unittest
+import zipfile
+
+import mock
 
 from mkdocs import config
 from mkdocs.compat import PY2, zip
@@ -16,7 +20,28 @@ def ensure_utf(string):
     return string.encode('utf-8') if PY2 else string
 
 
+def _create_mock_theme_zip(theme_dir, theme):
+    theme_path = os.path.join(theme_dir, theme)
+
+    tmp_dir = tempfile.mkdtemp()
+    zip_path = os.path.join(tmp_dir, 'yeti.zip')
+    zip_file = zipfile.ZipFile(zip_path, 'w')
+
+    for root, dirs, files in os.walk(theme_path):
+        for f in files:
+            arcname = "{0}/{1}".format(root.replace(theme_path, ''), f)
+            zip_file.write(os.path.join(root, f), arcname=arcname)
+    zip_file.close()
+    return open(zip_path, 'rb')
+
+
 class ConfigTests(unittest.TestCase):
+
+    def setUp(self):
+        super(ConfigTests, self).setUp()
+
+        self.themes_dir = os.path.join(os.path.dirname(__file__), '../themes/')
+
     def test_missing_config_file(self):
 
         def load_missing_config():
@@ -99,12 +124,19 @@ class ConfigTests(unittest.TestCase):
             finally:
                 os.remove(config_file.name)
 
-    def test_install_theme(self):
+    @mock.patch('mkdocs.utils.urlopen')
+    def test_install_theme(self, mock_urlopen):
+
+        theme_path = os.path.join(self.themes_dir, 'yeti')
         tmp_dir = tempfile.mkdtemp()
-        config.install_theme(
-            'https://github.com/ngzhian/mkdocs/raw/theme-url/mkdocs/tests/yeti.zip',
-            tmp_dir)
+        zip_file = _create_mock_theme_zip(self.themes_dir, "yeti")
+        mock_urlopen.return_value = zip_file
+
+        config.install_theme('https://fake-url.com', tmp_dir)
         self.assertTrue(os.path.exists, os.path.join(tmp_dir, 'yeti'))
+        c = filecmp.dircmp(os.path.join(tmp_dir, 'yeti'), theme_path)
+        self.assertEqual(c.left_only, [])
+        self.assertEqual(c.right_only, [])
 
     def test_default_pages(self):
         tmp_dir = tempfile.mkdtemp()

--- a/mkdocs/tests/integration.py
+++ b/mkdocs/tests/integration.py
@@ -44,7 +44,8 @@ def capture():
         out[1] = out[1].getvalue()
 
 
-def build(theme_name, output=None, config=None, quiet=False):
+def build(theme_name, output=None, config=None, quiet=False,
+          extra_options=None):
     """
     Given a theme name and output directory use the configuration
     for the MkDocs documentation and overwrite the site_dir and
@@ -55,7 +56,7 @@ def build(theme_name, output=None, config=None, quiet=False):
     serve = output is None
     options = {}
 
-    if not serve:
+    if theme_name is not None and not serve:
         if not os.path.exists(output):
             os.makedirs(output)
         options['site_dir'] = os.path.join(output, theme_name)
@@ -68,6 +69,10 @@ def build(theme_name, output=None, config=None, quiet=False):
 
     options['config'] = config
     options['theme'] = theme_name
+    options['verbose'] = True
+
+    if extra_options is not None:
+        options.update(extra_options)
 
     if serve:
         if not quiet:
@@ -101,6 +106,11 @@ def main(output=None, config=None, quiet=False):
     for theme in sorted(MKDOCS_THEMES):
 
         build(theme, output, config, quiet)
+
+    build('theme_url', output, config, quiet, extra_options={
+        'theme': None,
+        'theme_url': "https://github.com/mkdocs/mkdocs/raw/master/mkdocs/tests/yeti.zip",
+    })
 
     print("The theme builds are available in {0}".format(output))
 

--- a/mkdocs/utils.py
+++ b/mkdocs/utils.py
@@ -10,7 +10,7 @@ and structure of the site and pages in the site.
 import os
 import shutil
 
-from mkdocs.compat import urlparse
+from mkdocs.compat import urlparse, urlopen as urlopen_compat
 
 
 def copy_file(source_path, output_path):
@@ -204,3 +204,12 @@ def create_relative_media_url(nav, url):
         relative_url = ".%s" % relative_url
 
     return relative_url
+
+
+def urlopen(path):
+    """
+    Due to the nature of the compat module, we can't easily mock the urlopen
+    function as it is imported and defined dynamically depending if the user
+    is using Python 2 or 3. This utility exists simply to make mocking easier.
+    """
+    return urlopen_compat(path)


### PR DESCRIPTION
- Don't install themes into the site-packages, we don't want to edit
  that. It should be considered read-only for us. Instead, download the
  theme to a .mkdocs directory in the same location as the mkdocs.yml
- When installing a theme, use it like a custom theme would be used by
  adding it to the theme_dir.
- Rather than include a zip file in the tests, create one on the fly
  that can be used - this makes it more flxible and clearer what is
  happening.
- Compare the extracted theme with the original zipped theme
- Use a pre-build theme zip for integration tests only